### PR TITLE
 feat: significantly improve YAML peformance with workers

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,10 +255,12 @@ Hydrator has added support for asynchronous hydration of cluster and package man
 is disabled by default. To use, pass the `--workers` flag during invocation. For example:
 
 ```shell
-hydrate -v --workers=50 cluster sot.csv --gatekeeper-validation --split-output
+hydrate -v --workers=32 cluster sot.csv --gatekeeper-validation --split-output
 ```
 
-The recommended max number of workers is `50` based on testing.
+The recommended number of workers to use is 2 for every CPU core available. If you are still not seeing the performance
+improvements you would like, we recommend allocating more CPUs to hydrator and to increase the number of workers
+accordingly.  For example, if you have allocated 16 (v)CPUS, use 32 workers.
 
 Note that increasing the number of concurrent workers dramatically reduces the usefulness of hydrator output, as the
 output of concurrent tasks are writing to the console at the same time, commingling messages. If you are troubleshooting

--- a/src/hydrator/__main__.py
+++ b/src/hydrator/__main__.py
@@ -43,6 +43,13 @@ def main() -> int:
 
     logger.debug(f'Received args: {pprint.pformat(vars(args))}')
 
+    try:
+        # pylint: disable-next=protected-access,line-too-long
+        logger.debug(f'Running with GIL {'enabled' if sys._is_gil_enabled() else 'disabled'} '  # type: ignore
+                     f'on Python {sys.version}')
+    except AttributeError:
+        logger.debug(f'Running with GIL enabled on Python {sys.version}')
+
     cli: GroupCli | ClusterCli
     try:
         if args.type is HydrateType.CLUSTER:

--- a/src/hydrator/util.py
+++ b/src/hydrator/util.py
@@ -31,6 +31,7 @@ from typing import IO, Self, Any
 import aiofiles
 import aioshutil
 import jinja2
+import yaml
 
 from .exc import CliWarning, ConfigWarning, ConfigError
 from .types import BaseConfig
@@ -442,3 +443,11 @@ class InMemoryTextFile:
         async with aiofiles.open(file_path, 'r', encoding=inst.encoding) as f:
             inst.contents = await f.read()
         return inst
+
+
+def sync_load_all_yaml(content: str) -> list[Any]:
+    """ Calls yaml.load_all on the content string and consumes the generator into a list,
+    performing all parsing synchronously. The advantage is that the work isn't deferred, it's
+    completed immediately before returning which is beneficial to us from within a thread.
+    """
+    return list(yaml.load_all(content, Loader=yaml.CSafeLoader))


### PR DESCRIPTION
places sync YAML calls in threads, unblocking the event loop for dramatically improved performance, about 50% reduced time over previous asynchronous implementation with evented workers. Default recommendation is to use 2 workers per CPU core.