### PR TITLE
Fix YAML parsing for strings that can be interpreted as octets

### DIFF
--- a/src/hydrator/krm.py
+++ b/src/hydrator/krm.py
@@ -53,7 +53,19 @@ def represent_krm_resource(dumper: yaml.SafeDumper, data: KrmResource):
     return dumper.represent_dict(data.items())
 
 
+def represent_string(dumper: yaml.SafeDumper, data: str):
+    """ Custom YAML representer for strings to force quoting on numeric-looking strings
+    with leading zeros that PyYAML might otherwise leave unquoted.
+
+    Fixes https://github.com/yaml/pyyaml/issues/741
+    """
+    if data.isdigit() and data.startswith('0'):
+        return dumper.represent_scalar('tag:yaml.org,2002:str', data, style="'")
+    return dumper.represent_scalar('tag:yaml.org,2002:str', data)
+
+
 yaml.add_representer(KrmResource, represent_krm_resource, Dumper=yaml.CSafeDumper)  # type: ignore
+yaml.add_representer(str, represent_string, Dumper=yaml.CSafeDumper)  # type: ignore
 
 
 def krm_add_annotation(obj: dict, *, key: str, value: str) -> dict:

--- a/tests/assets/default_overlays/base_library/clusterdns/clusterdns.yaml.j2
+++ b/tests/assets/default_overlays/base_library/clusterdns/clusterdns.yaml.j2
@@ -2,6 +2,8 @@ apiVersion: networking.gke.io/v1alpha1
 kind: ClusterDNS
 metadata:
   name: default
+  labels:
+    store_id: "{{ cluster_name[2:7] }}"
 spec:
   upstreamNameservers:
 {% for ip in dns_servers.split(',')|map('trim') %}

--- a/tests/assets/platform_valid/base_library/clusterdns/clusterdns.yaml.j2
+++ b/tests/assets/platform_valid/base_library/clusterdns/clusterdns.yaml.j2
@@ -2,6 +2,8 @@ apiVersion: networking.gke.io/v1alpha1
 kind: ClusterDNS
 metadata:
   name: default
+  labels:
+    store_id: "{{ cluster_name[2:7] }}"
 spec:
   upstreamNameservers:
 {% for ip in dns_servers.split(',')|map('trim') %}

--- a/tests/assets/platform_valid/sot_zero_padded_ids.csv
+++ b/tests/assets/platform_valid/sot_zero_padded_ids.csv
@@ -1,0 +1,5 @@
+cluster_name,cluster_group,cluster_tags,dns_servers
+US00001CLS01,prod-us,"donotupgrade,corp","1.1.1.1,1.1.0.0"
+US09001CLS01,prod-us,"drivethruduallane,corp","1.1.1.1,1.1.0.0"
+US01111CLS01,nonprod-us,"donotupgrade","8.8.8.8,8.8.4.4"
+US11111CLS01,nonprod-us,"drivethruduallane","8.8.8.8,8.8.4.4"

--- a/tests/test_cluster_cli.py
+++ b/tests/test_cluster_cli.py
@@ -318,6 +318,33 @@ class TestClusterHydrationPlatformValidCases(unittest.TestCase):
 
         r.temp.cleanup()
 
+    def test_yaml1_1_quotes_split_output(self):
+        args = [*self.standard_args, "--split-output"]
+        r = run_cli('tests/assets/platform_valid/sot_zero_padded_ids.csv', subcommand_args=args)
+
+        self.assertEqual(0, r.proc.returncode)
+        self.assertIn("4 clusters total, all rendered successfully",
+                      r.proc.stdout)
+        self.assertFalse(r.proc.stderr)
+        with open('tests/assets/platform_valid/sot_zero_padded_ids.csv') as f:
+            reader = csv.reader(f)
+            next(reader)  # discard header
+            for name, group, _, _ in reader:
+                output_file = r.out.joinpath(f'{name}/{name}.yaml')
+                self.assertFalse(output_file.exists())
+
+                filepath = r.out.joinpath(f'{group}/{name}/clusterdns/clusterdns.yaml')
+                self.assertTrue(filepath.exists())
+                self.assertTrue(filepath.is_file())
+
+                with open(filepath) as f:
+                    doc = yaml.safe_load(f)
+                
+                # Ensure the digits extracted from store_id remain as a quoted string
+                self.assertEqual(doc['metadata']['labels']['store_id'], f"{name[2:7]}")
+
+        r.temp.cleanup()
+
 
 class TestDefaultOverlays(TestClusterHydrationPlatformValidCases):
     # we subclass the valid cases to ensure that everything behaves normally when we use

--- a/tests/test_yaml_quoting.py
+++ b/tests/test_yaml_quoting.py
@@ -1,0 +1,51 @@
+import unittest
+import pathlib
+import yaml
+from hydrator.krm import K8sResourceParser
+
+class TestYamlQuoting(unittest.IsolatedAsyncioTestCase):
+    async def test_leading_zero_quoting(self):
+        parser = K8sResourceParser()
+        yaml_input = """
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test-config
+data:
+  store_id_octal: "012345"
+  store_id_leading_zero: "09876"
+  store_id_normal: "12345"
+  store_id_zeros: "000"
+"""
+        path = pathlib.Path("test.yaml")
+        unique_id = "test-cluster"
+        
+        # This will load and then dump the YAML
+        output = await parser.process_yaml_string(yaml_input, path=path, unique_id=unique_id)
+        
+        self.assertTrue("'09876'" in output or '"09876"' in output, 
+                        "09876 should be quoted in the output")
+        
+        self.assertTrue("'012345'" in output or '"012345"' in output, 
+                        "012345 should be quoted in the output")
+        
+        self.assertTrue("'000'" in output or '"000"' in output, 
+                        "000 should be quoted in the output")
+        
+        self.assertTrue("'12345'" in output or '"12345"' in output, 
+                        "12345 should be quoted in the output")
+
+        # Load it back to make sure it's still a string and has the same value
+        loaded = list(yaml.safe_load_all(output))
+        self.assertEqual(loaded[0]['data']['store_id_leading_zero'], "09876")
+        self.assertEqual(loaded[0]['data']['store_id_octal'], "012345")
+        self.assertEqual(loaded[0]['data']['store_id_normal'], "12345")
+        self.assertEqual(loaded[0]['data']['store_id_zeros'], "000")
+        
+        self.assertIsInstance(loaded[0]['data']['store_id_leading_zero'], str)
+        self.assertIsInstance(loaded[0]['data']['store_id_octal'], str)
+        self.assertIsInstance(loaded[0]['data']['store_id_normal'], str)
+        self.assertIsInstance(loaded[0]['data']['store_id_zeros'], str)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
When using `--split-output`, string values that happen to be numbers with leading zeros get output as integer values. This can cause problems with K8s resources like configmap data or adding labels/annotation values as they always expect values to be strings.

This change uses a custom dumper with pyyaml to force quoting for these numeric values. 

## Repro

```
## SOT
cluster_name,cluster_group,cluster_tags,numeric_value
works,prod-us,,"12345"
did-not-work-correctly,prod-us,,"01234"

### jinja template
---
cluster_name: "{{cluster_name}}"
value: "{{numeric_value}}"
---
```

And what gets output

```
---
cluster_name: "works"
value: "12345"
---
cluster_name: "did-not-work-correctly"
value: 01234    # <---- Previously, hydrator with --split-output would drop the surrounding quotes
---
```

## Output with Fix

```
---
cluster_name: "works"
value: "12345"
---
cluster_name: "did-not-work-correctly"
value: "01234"   # <---- With this change, quotes are correctly preserved
```